### PR TITLE
 Fix for electrification in nested domain

### DIFF
--- a/elec/module_mp_nssl_2mom_elec.F
+++ b/elec/module_mp_nssl_2mom_elec.F
@@ -1347,7 +1347,9 @@ MODULE module_mp_nssl_2mom
       rho_qh   = nssl_params(8)
       rho_qhl  = nssl_params(9)
       rho_qs   = nssl_params(10)
+      IF ( ipelec == 0 ) THEN
       ipelec   = Nint(nssl_params(11))
+      ENDIF
       isaund   = Nint(nssl_params(12))
       IF ( Nint(nssl_params(13)) == 1 ) THEN
       ! hack to switch CCN field to CCNA (activated ccn)


### PR DESCRIPTION
Problem with nested domains: ipelec would be set to zero in NSSL module because domain 1 init was called after domain 2 somehow. No, ipelec is only set to the incoming value in the init routine if the current value is zero.

