### PR TITLE
Seg fault fix 

### DIFF
--- a/elec/include_microphysics_driver_elec.F
+++ b/elec/include_microphysics_driver_elec.F
@@ -832,7 +832,7 @@
      
       ELSE   ! ipelectmp.gt.0 - computes charging but not E and discharge- 
      
-     elec(:,:,:,:)=0.
+!     elec(:,:,:,:)=0.
      elecz(:,:,:)=0.
      light(:,:)=0.
      lightdens(:,:)=0.

--- a/external/RSL_LITE/rsl_malloc.c
+++ b/external/RSL_LITE/rsl_malloc.c
@@ -76,7 +76,7 @@
 #ifndef MACOS
 # include <malloc.h>
 #else
-# include <malloc/malloc.h>
+// # include <malloc/malloc.h>
 #endif
 #ifdef T3D
 #include <errno.h>


### PR DESCRIPTION
include_microphysics_driver_elec.F : Fix bug where elec array was written without being allocated (thanks to Debasish Mahapatra)

Fix rsl_malloc.c for OSX using gcc instead of clang


